### PR TITLE
Fix URL creation in renderer

### DIFF
--- a/packages/renderer/state/video-store.ts
+++ b/packages/renderer/state/video-store.ts
@@ -4,6 +4,7 @@ import { getNativePlayerInstance } from '../native-player';
 import * as VideoIPC from '../ipc/video';
 import * as FileIPC from '../ipc/file';
 import throttle from 'lodash/throttle';
+import { pathToFileURL } from 'url';
 
 type Meta = {
   duration: number;
@@ -82,7 +83,7 @@ export const useVideoStore = createWithEqualityFn<State & Actions>()(
       if (!fd) return;
 
       if ('path' in fd) {
-        const url = `file://${encodeURI(fd.path.replace(/\\/g, '/'))}`;
+        const url = pathToFileURL(fd.path).toString();
         set(s => {
           s.file = fd as any;
           s.path = fd.path;


### PR DESCRIPTION
## Summary
- use `pathToFileURL` in `video-store`

## Testing
- `bun run lint` *(fails: ESLint couldn't find a config file)*
- `bun run build` *(fails: bunx not found)*