### PR TITLE
Fix URL processor fileUrl

### DIFF
--- a/packages/main/services/url-processor/index.ts
+++ b/packages/main/services/url-processor/index.ts
@@ -9,6 +9,7 @@ import { PROGRESS } from './constants.js';
 import type { FFmpegContext } from '../ffmpeg-runner.js';
 import { FileManager } from '../file-manager.js';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { mapErrorToUserFriendly } from './error-map.js';
 import { defaultBrowserHint } from './utils.js';
 
@@ -89,7 +90,7 @@ export async function processVideoUrl(
       videoPath: downloadResult.filepath,
       filename,
       size: stats.size,
-      fileUrl: `file://${downloadResult.filepath}`,
+      fileUrl: pathToFileURL(downloadResult.filepath).href,
       originalVideoPath: downloadResult.filepath,
       proc: downloadResult.proc,
     };


### PR DESCRIPTION
## Summary
- import `pathToFileURL` from Node's url module in the url processor service
- generate file URL using `pathToFileURL(...).href`

## Testing
- `bun run lint` *(fails: couldn't find eslint.config.js)*
- `bun run --cwd packages/main build` *(fails: Cannot find type definition file for 'node')*