### PR TITLE
Add error reset on video URL change

### DIFF
--- a/packages/renderer/containers/VideoPlayer/NativeVideoPlayer.tsx
+++ b/packages/renderer/containers/VideoPlayer/NativeVideoPlayer.tsx
@@ -110,6 +110,10 @@ export default function NativeVideoPlayer({
   }, []);
 
   useEffect(() => {
+    setErrorMessage(null);
+  }, [videoUrl]);
+
+  useEffect(() => {
     const v = videoRef.current;
     if (!v) return;
 


### PR DESCRIPTION
## Summary
- clear any playback errors whenever the video URL changes

## Testing
- `bun run lint` *(fails: ESLint couldn't find a configuration file)*